### PR TITLE
Debug Dokploy deployment cloning error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,6 @@ services:
     restart: always
     ports:
       - "127.0.0.1:${PORT:-3000}:3000"
-      
-    env_file:
-      - ./backend/.env
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 3000


### PR DESCRIPTION
…v file

The env_file directive was causing Dokploy deployment to fail because backend/.env doesn't exist in the repository (correctly excluded for security). All environment variables are already defined in the environment section with defaults, so env_file was redundant.