### PR TITLE
fix(config): make ports configurable via environment variables for Do…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,14 @@
 # Application
 # ================================
 NODE_ENV=development
-PORT=3000
+
+# ================================
+# Ports Configuration (for Dokploy)
+# ================================
+# Backend port - NestJS API server
+BACKEND_PORT=3000
+# Frontend port - Next.js server
+FRONTEND_PORT=3000
 
 # ================================
 # Database (PostgreSQL)
@@ -33,7 +40,9 @@ JWT_EXPIRATION=24h
 # ================================
 # CORS Configuration
 # ================================
-FRONTEND_URL=http://localhost:8080
+# URL where frontend is accessible (for CORS)
+# In Dokploy, this will be your domain (e.g., https://app.rapidosur.cl)
+FRONTEND_URL=http://localhost:3000
 
 # ================================
 # Email Configuration
@@ -73,4 +82,6 @@ THROTTLE_LIMIT=10
 # ================================
 # Frontend (Next.js)
 # ================================
+# API URL that frontend uses to call backend
+# In Dokploy, use your backend domain (e.g., https://api.rapidosur.cl/api)
 NEXT_PUBLIC_API_URL=http://localhost:3000/api

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ npm run dev
 **Servicios iniciados**:
 - ✅ PostgreSQL en Docker (puerto 5432)
 - ✅ Backend con hot-reload (puerto 3000)
-- ✅ Frontend con hot-reload (puerto 8080)
+- ✅ Frontend con hot-reload (puerto 3000 por defecto, configurable vía FRONTEND_PORT)
 
 **Acceso**:
-- Frontend: http://localhost:8080
-- Backend: http://localhost:3000
+- Frontend: http://localhost:3000 (o el puerto configurado en FRONTEND_PORT)
+- Backend API: http://localhost:3000/api (o el puerto configurado en BACKEND_PORT)
 
 **Ventajas**:
 - ⚡ Muy rápido - inicia en segundos
@@ -79,8 +79,8 @@ docker-compose up -d
 
 **Servicios incluidos**:
 - ✅ PostgreSQL (puerto 5432)
-- ✅ Backend (puerto 3000)
-- ✅ Frontend (puerto 8080)
+- ✅ Backend (puerto configurable vía BACKEND_PORT, default 3000)
+- ✅ Frontend (puerto configurable vía FRONTEND_PORT, default 3000)
 
 📖 **Guía completa de Docker**: [DOCKER.md](./DOCKER.md)
 
@@ -123,7 +123,7 @@ cp .env.example .env.local
 npm run dev
 ```
 
-Frontend disponible en: http://localhost:8080
+Frontend disponible en: http://localhost:3000 (o el puerto configurado)
 
 ---
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -111,7 +111,7 @@ async function bootstrap() {
 
   // Enable CORS for frontend communication
   app.enableCors({
-    origin: process.env.FRONTEND_URL || "http://localhost:8080",
+    origin: process.env.FRONTEND_URL || "http://localhost:3000",
     credentials: true,
   });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,14 +39,14 @@ services:
       dockerfile: Dockerfile
       target: production
       args:
-        NODE_ENV: development
+        NODE_ENV: ${NODE_ENV:-development}
     container_name: rapido-sur-backend
     restart: always
     ports:
-      - "127.0.0.1:${PORT:-3000}:3000"
+      - "${BACKEND_PORT:-3000}:${BACKEND_PORT:-3000}"
     environment:
-      NODE_ENV: ${NODE_ENV:-development}
-      PORT: 3000
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${BACKEND_PORT:-3000}
 
       DB_HOST: postgres
       DB_PORT: 5432
@@ -59,7 +59,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:-RapidoSurDockerJWTSecretKey2025For DevelopmentAndProductionSixtyFourChars}
       JWT_EXPIRATION: ${JWT_EXPIRATION:-24h}
 
-      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:8080}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
 
       MAIL_HOST: ${MAIL_HOST:-smtp.gmail.com}
       MAIL_PORT: ${MAIL_PORT:-587}
@@ -95,7 +95,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          'node -e "require(\"http\").get(\"http://localhost:3000/api/health\", (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"',
+          "wget --no-verbose --tries=1 --spider http://localhost:${BACKEND_PORT:-3000}/api/health || exit 1",
         ]
       interval: 30s
       timeout: 10s
@@ -113,15 +113,16 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_API_URL: http://backend:3000/api
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:3000/api}
+        FRONTEND_PORT: ${FRONTEND_PORT:-3000}
     container_name: rapido-sur-frontend
     restart: always
     ports:
-      - "127.0.0.1:8080:8080"
+      - "${FRONTEND_PORT:-3000}:${FRONTEND_PORT:-3000}"
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3000/api}
       NODE_ENV: production
-      PORT: 8080
+      PORT: ${FRONTEND_PORT:-3000}
       HOSTNAME: "0.0.0.0"
     depends_on:
       backend:
@@ -137,7 +138,7 @@ services:
           cpus: "0.25"
           memory: 128M
     healthcheck:
-      test: ["CMD-SHELL", "netstat -an | grep 8080 > /dev/null || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:${FRONTEND_PORT:-3000}/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker.sh
+++ b/docker.sh
@@ -80,8 +80,8 @@ case "${1:-help}" in
         success "Servicios levantados"
         echo ""
         info "Acceso:"
-        echo "  Frontend: ${GREEN}http://localhost:8080${NC}"
-        echo "  Backend:  ${GREEN}http://localhost:3000${NC}"
+        echo "  Frontend: ${GREEN}http://localhost:${FRONTEND_PORT:-3000}${NC}"
+        echo "  Backend:  ${GREEN}http://localhost:${BACKEND_PORT:-3000}${NC}"
         echo "  Database: ${GREEN}localhost:5432${NC}"
         ;;
     

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,6 +32,11 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Port configuration via build arg (default 3000 for Dokploy compatibility)
+ARG FRONTEND_PORT=3000
+ENV PORT=${FRONTEND_PORT}
+ENV HOSTNAME="0.0.0.0"
+
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -48,11 +53,8 @@ RUN chown -R nextjs:nodejs /app
 # Switch to non-root user
 USER nextjs
 
-# Expose port
-EXPOSE 8080
-
-ENV PORT=8080
-ENV HOSTNAME="0.0.0.0"
+# Expose port (uses ARG value)
+EXPOSE ${FRONTEND_PORT}
 
 # Start the application using next start
 CMD ["npm", "start"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,7 +8,7 @@ http {
     }
 
     upstream backend {
-        server backend:8080;
+        server backend:3000;
     }
 
     # Rate limiting

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev -p 8080",
+    "dev": "next dev -p ${PORT:-3000}",
     "docker:build": "docker build -t rapido-sur-frontend:latest .",
     "docker:compose:down": "docker-compose down",
     "docker:compose:logs": "docker-compose logs -f",
     "docker:compose:up": "docker-compose up -d",
-    "docker:run": "docker run -p 8080:3000 rapido-sur-frontend:latest",
+    "docker:run": "docker run -p 3000:3000 rapido-sur-frontend:latest",
     "lint": "eslint .",
-    "start": "next start -p 8080"
+    "start": "next start"
   },
   "dependencies": {
     "@hookform/resolvers": "latest",


### PR DESCRIPTION
…kploy

- Add BACKEND_PORT and FRONTEND_PORT environment variables
- Change default port from 8080 to 3000 for Dokploy compatibility
- Fix nginx.conf upstream backend port (was 8080, should be 3000)
- Update docker-compose.yml to use dynamic port variables
- Update healthchecks to use wget instead of node for reliability
- Update frontend Dockerfile to accept port as build arg
- Update .env.example with new port configuration section
- Update README.md to reflect configurable ports