### PR TITLE
fix(frontend): properly pass NEXT_PUBLIC_API_URL as build arg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,14 +113,18 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:3000/api}
+        # CRITICAL: NEXT_PUBLIC_API_URL is baked into the JS bundle at build time
+        # For Dokploy: Set this to your backend's internal URL (e.g., http://backend:3002/api)
+        # The port MUST match BACKEND_PORT (default: 3000)
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:${BACKEND_PORT:-3000}/api}
         FRONTEND_PORT: ${FRONTEND_PORT:-3000}
     container_name: rapido-sur-frontend
     restart: always
     ports:
       - "${FRONTEND_PORT:-3000}:${FRONTEND_PORT:-3000}"
     environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3000/api}
+      # Note: NEXT_PUBLIC_* vars have NO effect at runtime - they're baked in at build time
+      # This is kept for documentation purposes only
       NODE_ENV: production
       PORT: ${FRONTEND_PORT:-3000}
       HOSTNAME: "0.0.0.0"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,11 +18,17 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# CRITICAL: NEXT_PUBLIC_* variables must be set at BUILD time
+# They get embedded into the JavaScript bundle during 'npm run build'
+# Setting them at runtime has NO effect
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+
 # Set environment variables for build
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
-# Build the application
+# Build the application (NEXT_PUBLIC_API_URL is now available)
 RUN npm run build
 
 # Stage 3: Runner


### PR DESCRIPTION
Next.js NEXT_PUBLIC_* variables are embedded into the JavaScript bundle at BUILD time, not runtime. The frontend Dockerfile was missing the ARG declaration, causing the fallback http://localhost:3000/api to be baked into the production build.

Changes:
- frontend/Dockerfile: Add ARG and ENV for NEXT_PUBLIC_API_URL in builder stage
- docker-compose.yml: Use BACKEND_PORT variable in default API URL
- docker-compose.yml: Remove ineffective runtime NEXT_PUBLIC_API_URL env var
- Add clarifying comments about build-time vs runtime behavior

For Dokploy deployment with BACKEND_PORT=3002, ensure NEXT_PUBLIC_API_URL is set to http://backend:3002/api (or the public backend URL) in the build args.