### PR TITLE
chore: cerrar pendientes de mantenimiento (ramas, eslint v9, logs/backups, tests FR-02)

### DIFF
--- a/backend/src/modules/alerts/alerts.service.spec.ts
+++ b/backend/src/modules/alerts/alerts.service.spec.ts
@@ -6,7 +6,9 @@ import { Alerta } from "./entities/alerta.entity";
 import { PlanPreventivo } from "../preventive-plans/entities/plan-preventivo.entity";
 import { Vehiculo } from "../vehicles/entities/vehiculo.entity";
 import { MailService } from "../mail/mail.service";
-import { EstadoVehiculo, TipoAlerta, TipoIntervalo } from "../../common/enums";
+import { EventsGateway } from "../websockets/events.gateway";
+import { OrdenTrabajo } from "../work-orders/entities/orden-trabajo.entity";
+import { EstadoVehiculo, TipoAlerta, TipoIntervalo, EstadoAlerta, EstadoOrdenTrabajo, TipoOrdenTrabajo } from "../../common/enums";
 
 describe("AlertsService", () => {
   let service: AlertsService;
@@ -14,6 +16,7 @@ describe("AlertsService", () => {
   let planRepo: Repository<PlanPreventivo>;
   let vehiculoRepo: Repository<Vehiculo>;
   let mailService: MailService;
+  let otRepo: Repository<OrdenTrabajo>;
 
   const mockAlertaRepo = {
     create: jest.fn(),
@@ -36,6 +39,16 @@ describe("AlertsService", () => {
     enviarAlertasPreventivas: jest.fn(),
   };
 
+  const mockOtRepo = {
+    createQueryBuilder: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockEventsGateway = {
+    emitAlertCreated: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -53,8 +66,16 @@ describe("AlertsService", () => {
           useValue: mockVehiculoRepo,
         },
         {
+          provide: getRepositoryToken(OrdenTrabajo),
+          useValue: mockOtRepo,
+        },
+        {
           provide: MailService,
           useValue: mockMailService,
+        },
+        {
+          provide: EventsGateway,
+          useValue: mockEventsGateway,
         },
       ],
     }).compile();
@@ -68,11 +89,13 @@ describe("AlertsService", () => {
       getRepositoryToken(Vehiculo),
     );
     mailService = module.get<MailService>(MailService);
+    otRepo = module.get<Repository<OrdenTrabajo>>(getRepositoryToken(OrdenTrabajo));
 
     jest.clearAllMocks();
     
     // Setup default mock for createQueryBuilder
     const mockQB = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       getMany: jest.fn().mockResolvedValue([]),
@@ -186,7 +209,7 @@ describe("AlertsService", () => {
 
       const createdAlert = mockAlertaRepo.create.mock.calls[0][0];
       expect(createdAlert.mensaje).toContain("ATRASADO");
-      expect(createdAlert.mensaje).toContain("1500");
+      expect(createdAlert.mensaje).toMatch(/1,?500/);
     });
 
     it("should NOT generate alert when vehicle is more than 1000 km before threshold", async () => {
@@ -407,6 +430,7 @@ describe("AlertsService", () => {
 
       // Setup createQueryBuilder to return existing alert
       const mockQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([existingAlert]),
@@ -575,10 +599,54 @@ describe("AlertsService", () => {
       const result = await service.findAll();
 
       expect(alertaRepo.find).toHaveBeenCalledWith({
-        relations: ["vehiculo"],
+        relations: ["vehiculo", "orden_trabajo", "descartada_por"],
         order: { fecha_generacion: "DESC" },
       });
       expect(result).toEqual(mockAlertas);
     });
   });
+
+  describe("crearOrdenTrabajoDesdeAlerta", () => {
+    it("should create a preventive work order from a valid alert", async () => {
+      const alerta = {
+        id: 10,
+        mensaje: "TEST ALERT",
+        estado: EstadoAlerta.Pendiente,
+        vehiculo: {
+          id: 2,
+          patente: "AA-BB-22",
+          plan_preventivo: { descripcion: "Cada 10.000 km" },
+        },
+      } as any;
+
+      mockAlertaRepo.findOne.mockResolvedValue(alerta);
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      mockOtRepo.createQueryBuilder.mockReturnValue(qb);
+      mockOtRepo.create.mockImplementation((data) => data);
+      mockOtRepo.save.mockImplementation(async (data) => ({ id: 55, ...data }));
+      mockAlertaRepo.save.mockImplementation(async (data) => data);
+
+      const result = await service.crearOrdenTrabajoDesdeAlerta(10, "Revisar frenos");
+
+      expect(mockOtRepo.create).toHaveBeenCalled();
+      expect(mockOtRepo.save).toHaveBeenCalled();
+      expect(mockAlertaRepo.save).toHaveBeenCalled();
+      expect(result.tipo).toBe(TipoOrdenTrabajo.Preventivo);
+      expect(result.estado).toBe(EstadoOrdenTrabajo.Pendiente);
+      expect(result.numero_ot).toMatch(/^OT-\d{4}-\d{5}$/);
+    });
+
+    it("should fail if alert does not exist", async () => {
+      mockAlertaRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.crearOrdenTrabajoDesdeAlerta(999)).rejects.toThrow(
+        "Alerta con ID 999 no encontrada",
+      );
+    });
+  });
+
 });

--- a/devops/README.md
+++ b/devops/README.md
@@ -9,7 +9,9 @@ devops/
 ├── README.md                    # Este archivo
 └── scripts/
     ├── docker.sh                # Helper para Docker en desarrollo
-    └── diagnose-production.sh   # Diagnóstico de producción
+    ├── diagnose-production.sh   # Diagnóstico de producción
+    ├── cleanup-branches.sh      # Limpieza de ramas remotas mergeadas
+    └── cleanup-logs-backups.sh  # Limpieza de logs/backups antiguos
 ```
 
 ---
@@ -87,6 +89,52 @@ docker exec -it [nombre-contenedor] bash
 - Después de hacer deploy en Dokploy para validar que todo está corriendo
 - Cuando sospechas que hay un problema en producción
 - Para debugging de problemas de conexión BD/API
+
+---
+
+## 🧹 cleanup-branches.sh
+
+**Descripción:** Detecta ramas remotas mergeadas en `origin/main` y las elimina de forma segura (excluye ramas protegidas).
+
+**Ubicación:** `devops/scripts/cleanup-branches.sh`
+
+**Uso:**
+
+```bash
+# Simulación (recomendado)
+./devops/scripts/cleanup-branches.sh --dry-run
+
+# Ejecución real
+./devops/scripts/cleanup-branches.sh --execute
+```
+
+**Protecciones incluidas:**
+- Nunca elimina `main/master/develop/dev/staging/production/release/*`
+- Siempre requiere fetch/prune previo
+- Tiene modo dry-run por defecto
+
+---
+
+## 🗂️ cleanup-logs-backups.sh
+
+**Descripción:** Limpia logs `.log` y backups `backup-*.sql.gz` más antiguos que un umbral (30 días por defecto).
+
+**Ubicación:** `devops/scripts/cleanup-logs-backups.sh`
+
+**Uso:**
+
+```bash
+# Simulación
+LOG_DIR=/var/log/rapido-sur BACKUP_DIR=/opt/rapido-sur/backups \
+  ./devops/scripts/cleanup-logs-backups.sh --dry-run
+
+# Ejecución real
+LOG_DIR=/var/log/rapido-sur BACKUP_DIR=/opt/rapido-sur/backups \
+  ./devops/scripts/cleanup-logs-backups.sh --execute
+
+# Cambiar retención (ej. 45 días)
+./devops/scripts/cleanup-logs-backups.sh --dry-run --days=45
+```
 
 ---
 

--- a/devops/scripts/cleanup-branches.sh
+++ b/devops/scripts/cleanup-branches.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cleanup merged remote branches in origin, preserving protected branches.
+# Usage:
+#   ./devops/scripts/cleanup-branches.sh --dry-run
+#   ./devops/scripts/cleanup-branches.sh --execute
+
+MODE="dry-run"
+if [[ "${1:-}" == "--execute" ]]; then
+  MODE="execute"
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "[ERROR] Ejecuta este script dentro de un repositorio git"
+  exit 1
+fi
+
+echo "[INFO] Fetching latest refs..."
+git fetch origin --prune
+
+PROTECTED_REGEX='^(main|master|develop|dev|staging|production|release/.*)$'
+
+mapfile -t merged_branches < <(
+  git branch -r --merged origin/main \
+    | grep -v -- '->' \
+    | sed 's#^\s*origin/##' \
+    | grep -v '^HEAD$' \
+    | grep -v -E "$PROTECTED_REGEX" \
+    | sort -u
+)
+
+if [[ ${#merged_branches[@]} -eq 0 ]]; then
+  echo "[OK] No hay ramas remotas mergeadas para limpiar."
+  exit 0
+fi
+
+echo "[INFO] Ramas candidatas a eliminar (${#merged_branches[@]}):"
+for b in "${merged_branches[@]}"; do
+  echo " - $b"
+done
+
+if [[ "$MODE" == "dry-run" ]]; then
+  echo "[DRY-RUN] No se eliminó ninguna rama. Usa --execute para aplicar cambios."
+  exit 0
+fi
+
+echo "[INFO] Eliminando ramas remotas..."
+for b in "${merged_branches[@]}"; do
+  echo "[DELETE] origin/$b"
+  git push origin --delete "$b"
+done
+
+echo "[OK] Limpieza de ramas remotas finalizada."

--- a/devops/scripts/cleanup-logs-backups.sh
+++ b/devops/scripts/cleanup-logs-backups.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cleanup operational files older than retention days.
+# Default paths are aligned with PLAN_IMPLEMENTACION_MANTENCION.md
+# Usage:
+#   LOG_DIR=/var/log/rapido-sur BACKUP_DIR=/opt/rapido-sur/backups ./devops/scripts/cleanup-logs-backups.sh --dry-run
+#   LOG_DIR=/var/log/rapido-sur BACKUP_DIR=/opt/rapido-sur/backups ./devops/scripts/cleanup-logs-backups.sh --execute
+
+MODE="dry-run"
+RETENTION_DAYS="30"
+
+for arg in "$@"; do
+  case "$arg" in
+    --execute) MODE="execute" ;;
+    --dry-run) MODE="dry-run" ;;
+    --days=*) RETENTION_DAYS="${arg#*=}" ;;
+  esac
+done
+
+LOG_DIR="${LOG_DIR:-/var/log/rapido-sur}"
+BACKUP_DIR="${BACKUP_DIR:-/opt/rapido-sur/backups}"
+
+echo "[INFO] Mode: $MODE"
+echo "[INFO] Retention: ${RETENTION_DAYS} días"
+echo "[INFO] Logs dir: $LOG_DIR"
+echo "[INFO] Backups dir: $BACKUP_DIR"
+
+find_old() {
+  local dir="$1"
+  local pattern="$2"
+  if [[ -d "$dir" ]]; then
+    find "$dir" -type f -name "$pattern" -mtime "+$RETENTION_DAYS"
+  fi
+}
+
+mapfile -t old_logs < <(find_old "$LOG_DIR" "*.log")
+mapfile -t old_backups < <(find_old "$BACKUP_DIR" "backup-*.sql.gz")
+
+if [[ ${#old_logs[@]} -eq 0 && ${#old_backups[@]} -eq 0 ]]; then
+  echo "[OK] No hay archivos antiguos para limpiar."
+  exit 0
+fi
+
+if [[ ${#old_logs[@]} -gt 0 ]]; then
+  echo "[INFO] Logs antiguos (${#old_logs[@]}):"
+  printf ' - %s\n' "${old_logs[@]}"
+fi
+
+if [[ ${#old_backups[@]} -gt 0 ]]; then
+  echo "[INFO] Backups antiguos (${#old_backups[@]}):"
+  printf ' - %s\n' "${old_backups[@]}"
+fi
+
+if [[ "$MODE" == "dry-run" ]]; then
+  echo "[DRY-RUN] No se eliminó ningún archivo. Usa --execute para aplicar cambios."
+  exit 0
+fi
+
+for f in "${old_logs[@]}"; do rm -f "$f"; done
+for f in "${old_backups[@]}"; do rm -f "$f"; done
+
+echo "[OK] Limpieza de logs y backups completada."

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,23 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: [".next/**", "node_modules/**", "out/**", "dist/**"],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.{js,mjs,cjs,ts,tsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    rules: {
+      "no-console": ["warn", { allow: ["warn", "error"] }],
+    },
+  },
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,11 @@
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
     "tw-animate-css": "1.3.3",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "eslint": "^9.18.0",
+    "@eslint/js": "^9.18.0",
+    "globals": "^16.0.0",
+    "typescript-eslint": "^8.20.0",
+    "eslint-config-next": "15.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,11 @@
     "migration:generate": "npm run migration:generate --workspace=backend",
     "migration:run": "npm run migration:run --workspace=backend",
     "migration:revert": "npm run migration:revert --workspace=backend",
-    "seed": "npm run seed --workspace=backend"
+    "seed": "npm run seed --workspace=backend",
+    "ops:cleanup-branches": "./devops/scripts/cleanup-branches.sh --dry-run",
+    "ops:cleanup-branches:execute": "./devops/scripts/cleanup-branches.sh --execute",
+    "ops:cleanup-files": "./devops/scripts/cleanup-logs-backups.sh --dry-run",
+    "ops:cleanup-files:execute": "./devops/scripts/cleanup-logs-backups.sh --execute"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",


### PR DESCRIPTION
## Resumen
Esta PR aborda pendientes documentados de mantenimiento operativo y técnico del proyecto.

## Problemas resueltos

### 1) Limpieza de ramas obsoletas
- Se agregó script seguro `devops/scripts/cleanup-branches.sh` con:
  - modo `--dry-run` por defecto
  - modo `--execute`
  - exclusión de ramas protegidas (`main/master/develop/dev/staging/production/release/*`)
- **Acción ejecutada**: se eliminaron ramas remotas mergeadas obsoletas (`claude/*` y `feature/*`) para reducir conflictos.

### 3) Actualización configuración ESLint v9
- Se agregó `frontend/eslint.config.mjs` (Flat Config compatible con ESLint v9).
- Se actualizaron dependencias del frontend para soporte ESLint v9 (`eslint`, `@eslint/js`, `globals`, `typescript-eslint`).

### 4) Optimización de logs y backup reset
- Se agregó `devops/scripts/cleanup-logs-backups.sh` para limpieza por retención (30 días por defecto):
  - logs `*.log`
  - backups `backup-*.sql.gz`
- Soporta `--dry-run`, `--execute` y `--days=N`.

### 5) Testing/Validación FR-02 (alertas preventivas)
- Se reforzó `backend/src/modules/alerts/alerts.service.spec.ts`:
  - mocks actualizados para query builder optimizado
  - pruebas para creación de OT desde alerta
  - validación de errores para alerta inexistente
  - ajuste de expectativas de formato numérico local

## Validaciones ejecutadas
- `npm run backend:build` ✅
- `npm run backend:test -- --runInBand src/modules/alerts/alerts.service.spec.ts` ✅
  - Total: 20
  - Passed: 20
  - Failed: 0
  - Skipped: 0
- `npm run frontend:lint` ⚠️
  - El comando ya corre con ESLint v9 + flat config, pero el frontend mantiene deuda histórica de lint (errores preexistentes no abordados en esta PR).

## Notas
- También se actualizaron scripts de conveniencia en `package.json` para ejecutar limpieza de ramas y limpieza de archivos operativos.